### PR TITLE
Fixing blog posts and syncing dev environment with github pages environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ permalink: pretty
 defaults:
   -
     scope:
-      path: "blog/_posts"
+      path: "blog"
       type: "posts"
     values:
       layout: "post"

--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,6 @@ author:
   name: pladd
   email: itspladd@gmail.com
 
-markdown: kramdown
-
 excerpt_separator: <!--more-->
 
 permalink: pretty

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -26,8 +26,8 @@ layout: default
 <section>
     <article>
         <h3>Chapter {{ page.chapter }}: {{ page.chapter-title }}</h3>
+        <span class="date-author">Posted by {{ page.author }} on {{ page.date | date: '%B %d, %Y' }}</span>
         {{ content }}
         {% include prev-next.html %}
-        <span class="date-author">Posted by {{ page.author }} on {{ page.date | date: '%B %d, %Y' }}</span>
     </article>
 </section>


### PR DESCRIPTION
The main problem is that in _config.yaml, using path: "blog/_posts" stopped working in the live version for some reason - using path: "blog" instead works.
