### PR TITLE
sidebar stays in place instead of snapping

### DIFF
--- a/assets/sidebar.js
+++ b/assets/sidebar.js
@@ -1,9 +1,18 @@
 window.onscroll = function() {moveSidebar()};
+window.onresize = function() {contentDivRect = contentDiv.getBoundingClientRect(); moveSidebar();};
 var sidebar;
 var sidebarOffset;
-function findSidebar() {
+var sidebarPosition;
+var sidebarWidth;
+var contentDiv;
+var contentDivRect;
+function findSidebarAndContentDiv() {
     sidebar = document.getElementsByClassName("sidebar")[0];
+    contentDiv = document.getElementById("content");
+    
     sidebarOffset = sidebar.offsetTop - 10 + sidebar.offsetParent.offsetTop;
+    sidebarWidth = sidebar.scrollWidth;
+    contentDivRect = contentDiv.getBoundingClientRect();
 }
 function moveSidebar() {
     var marginToTop = window.pageYOffset - sidebarOffset + 10;
@@ -12,14 +21,15 @@ function moveSidebar() {
         sidebar.style.marginTop = "10px";
     }
     if (window.pageYOffset >= sidebarOffset) {
+        sidebarPosition = (contentDivRect.right - sidebarWidth) + "px";
         sidebar.style.position = "fixed";
         sidebar.style.top = "0px";
-        sidebar.style.right = "10px";
+        sidebar.style.left = sidebarPosition;
     }
 }
 function doSidebar() {
     if (document.getElementsByClassName("sidebar")[0]) {
-        findSidebar();
+        findSidebarAndContentDiv();
         moveSidebar();
     }
 }


### PR DESCRIPTION
sidebar.js now uses getBoundingClientRect to find the position of the
content div within the window, and plugs the sidebar into the correct
position relative to the content div when you scroll down far enough.

On window resize, sidebar.js re-calculates the content div's location
relative to the viewpane and re-moves the sidebar.
